### PR TITLE
Adhere to ESLint/PHPCS and allow for translations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+	root: true,
+	extends: [
+		'wordpress'
+	],
+	env: {
+		browser: false,
+		node: true
+	},
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2018,
+		ecmaFeatures: {
+			jsx: true
+		}
+	},
+	settings: {
+		react: {
+			pragma: 'wp'
+		}
+	}
+};

--- a/build/block.built.js
+++ b/build/block.built.js
@@ -319,7 +319,7 @@ var langs = {
 };
 
 var addSyntaxToCodeBlock = function addSyntaxToCodeBlock(settings) {
-	if ('core/code' !== settings.name) {
+	if (settings.name !== 'core/code') {
 		return settings;
 	}
 

--- a/build/block.built.js
+++ b/build/block.built.js
@@ -67,7 +67,7 @@
 /* 0 */
 /***/ (function(module, exports) {
 
-var core = module.exports = { version: '2.5.4' };
+var core = module.exports = { version: '2.5.7' };
 if (typeof __e == 'number') __e = core; // eslint-disable-line no-undef
 
 
@@ -143,7 +143,7 @@ module.exports = function (it) {
 
 // 19.1.2.14 / 15.2.3.14 Object.keys(O)
 var $keys = __webpack_require__(17);
-var enumBugKeys = __webpack_require__(25);
+var enumBugKeys = __webpack_require__(26);
 
 module.exports = Object.keys || function keys(O) {
   return $keys(O, enumBugKeys);
@@ -202,8 +202,8 @@ module.exports = function (it) {
 
 var global = __webpack_require__(2);
 var core = __webpack_require__(0);
-var ctx = __webpack_require__(27);
-var hide = __webpack_require__(29);
+var ctx = __webpack_require__(28);
+var hide = __webpack_require__(30);
 var has = __webpack_require__(8);
 var PROTOTYPE = 'prototype';
 
@@ -272,11 +272,11 @@ module.exports = $export;
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_babel_runtime_core_js_object_keys__ = __webpack_require__(14);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_babel_runtime_core_js_object_keys___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_babel_runtime_core_js_object_keys__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_babel_runtime_helpers_extends__ = __webpack_require__(36);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_babel_runtime_helpers_extends__ = __webpack_require__(37);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_babel_runtime_helpers_extends___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_babel_runtime_helpers_extends__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__editor_scss__ = __webpack_require__(43);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__editor_scss__ = __webpack_require__(44);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__editor_scss___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__editor_scss__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__style_scss__ = __webpack_require__(44);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__style_scss__ = __webpack_require__(45);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__style_scss___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__style_scss__);
 
 
@@ -286,8 +286,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
  */
 
 /**
-* WordPress dependencies
-*/
+ * WordPress dependencies
+ */
 var __ = wp.i18n.__;
 var addFilter = wp.hooks.addFilter;
 var _wp$editor = wp.editor,
@@ -303,23 +303,23 @@ var SelectControl = wp.components.SelectControl;
 
 
 var langs = {
-	bash: 'Bash (shell)',
-	clike: 'C-like',
-	css: 'CSS',
-	git: 'Git',
-	go: 'Go (golang)',
-	markup: 'HTML/Markup',
-	javascript: 'JavaScript',
-	json: 'JSON',
-	markdown: 'Markdown',
-	php: 'PHP',
-	python: 'Python',
-	jsx: 'React JSX',
-	sql: 'SQL'
+	bash: __('Bash (shell)', 'code-syntax-block'),
+	clike: __('C-like', 'code-syntax-block'),
+	css: __('CSS', 'code-syntax-block'),
+	git: __('Git', 'code-syntax-block'),
+	go: __('Go (golang)', 'code-syntax-block'),
+	markup: __('HTML/Markup', 'code-syntax-block'),
+	javascript: __('JavaScript', 'code-syntax-block'),
+	json: __('JSON', 'code-syntax-block'),
+	markdown: __('Markdown', 'code-syntax-block'),
+	php: __('PHP', 'code-syntax-block'),
+	python: __('Python', 'code-syntax-block'),
+	jsx: __('React JSX', 'code-syntax-block'),
+	sql: __('SQL', 'code-syntax-block')
 };
 
 var addSyntaxToCodeBlock = function addSyntaxToCodeBlock(settings) {
-	if (settings.name !== "core/code") {
+	if ('core/code' !== settings.name) {
 		return settings;
 	}
 
@@ -347,25 +347,25 @@ var addSyntaxToCodeBlock = function addSyntaxToCodeBlock(settings) {
 
 			return [React.createElement(
 				InspectorControls,
-				null,
+				{ key: 'controls' },
 				React.createElement(SelectControl, {
 					label: 'Language',
 					value: attributes.language,
-					options: [{ label: __('Select code language'), value: '' }].concat(__WEBPACK_IMPORTED_MODULE_0_babel_runtime_core_js_object_keys___default()(langs).map(function (lang) {
+					options: [{ label: __('Select code language', 'code-syntax-block'), value: '' }].concat(__WEBPACK_IMPORTED_MODULE_0_babel_runtime_core_js_object_keys___default()(langs).map(function (lang) {
 						return { label: langs[lang], value: lang };
 					})),
 					onChange: updateLanguage
 				})
 			), React.createElement(
 				'div',
-				{ className: className },
+				{ key: 'editor-wrapper', className: className },
 				React.createElement(PlainText, {
 					value: attributes.content,
 					onChange: function onChange(content) {
 						return setAttributes({ content: content });
 					},
-					placeholder: __('Write code…'),
-					'aria-label': __('Code')
+					placeholder: __('Write code…', 'code-syntax-block'),
+					'aria-label': __('Code', 'code-syntax-block')
 				}),
 				React.createElement(
 					'div',
@@ -377,7 +377,7 @@ var addSyntaxToCodeBlock = function addSyntaxToCodeBlock(settings) {
 		save: function save(_ref2) {
 			var attributes = _ref2.attributes;
 
-			var cls = attributes.language ? "language-" + attributes.language : "";
+			var cls = attributes.language ? 'language-' + attributes.language : '';
 			return React.createElement(
 				'pre',
 				null,
@@ -394,7 +394,7 @@ var addSyntaxToCodeBlock = function addSyntaxToCodeBlock(settings) {
 };
 
 // Register Filter
-addFilter("blocks.registerBlockType", "mkaz/code-syntax-block", addSyntaxToCodeBlock);
+addFilter('blocks.registerBlockType', 'mkaz/code-syntax-block', addSyntaxToCodeBlock);
 
 /***/ }),
 /* 14 */
@@ -418,7 +418,7 @@ module.exports = __webpack_require__(0).Object.keys;
 var toObject = __webpack_require__(5);
 var $keys = __webpack_require__(7);
 
-__webpack_require__(26)('keys', function () {
+__webpack_require__(27)('keys', function () {
   return function keys(it) {
     return $keys(toObject(it));
   };
@@ -518,7 +518,7 @@ module.exports = function (index, length) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var shared = __webpack_require__(23)('keys');
-var uid = __webpack_require__(24);
+var uid = __webpack_require__(25);
 module.exports = function (key) {
   return shared[key] || (shared[key] = uid(key));
 };
@@ -528,16 +528,29 @@ module.exports = function (key) {
 /* 23 */
 /***/ (function(module, exports, __webpack_require__) {
 
+var core = __webpack_require__(0);
 var global = __webpack_require__(2);
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || (global[SHARED] = {});
-module.exports = function (key) {
-  return store[key] || (store[key] = {});
-};
+
+(module.exports = function (key, value) {
+  return store[key] || (store[key] = value !== undefined ? value : {});
+})('versions', []).push({
+  version: core.version,
+  mode: __webpack_require__(24) ? 'pure' : 'global',
+  copyright: '© 2018 Denis Pushkarev (zloirock.ru)'
+});
 
 
 /***/ }),
 /* 24 */
+/***/ (function(module, exports) {
+
+module.exports = true;
+
+
+/***/ }),
+/* 25 */
 /***/ (function(module, exports) {
 
 var id = 0;
@@ -548,7 +561,7 @@ module.exports = function (key) {
 
 
 /***/ }),
-/* 25 */
+/* 26 */
 /***/ (function(module, exports) {
 
 // IE 8- don't enum bug keys
@@ -558,7 +571,7 @@ module.exports = (
 
 
 /***/ }),
-/* 26 */
+/* 27 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // most Object methods by ES6 should accept primitives
@@ -574,11 +587,11 @@ module.exports = function (KEY, exec) {
 
 
 /***/ }),
-/* 27 */
+/* 28 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // optional / simple context binding
-var aFunction = __webpack_require__(28);
+var aFunction = __webpack_require__(29);
 module.exports = function (fn, that, length) {
   aFunction(fn);
   if (that === undefined) return fn;
@@ -600,7 +613,7 @@ module.exports = function (fn, that, length) {
 
 
 /***/ }),
-/* 28 */
+/* 29 */
 /***/ (function(module, exports) {
 
 module.exports = function (it) {
@@ -610,11 +623,11 @@ module.exports = function (it) {
 
 
 /***/ }),
-/* 29 */
+/* 30 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var dP = __webpack_require__(30);
-var createDesc = __webpack_require__(35);
+var dP = __webpack_require__(31);
+var createDesc = __webpack_require__(36);
 module.exports = __webpack_require__(4) ? function (object, key, value) {
   return dP.f(object, key, createDesc(1, value));
 } : function (object, key, value) {
@@ -624,12 +637,12 @@ module.exports = __webpack_require__(4) ? function (object, key, value) {
 
 
 /***/ }),
-/* 30 */
+/* 31 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var anObject = __webpack_require__(31);
-var IE8_DOM_DEFINE = __webpack_require__(32);
-var toPrimitive = __webpack_require__(34);
+var anObject = __webpack_require__(32);
+var IE8_DOM_DEFINE = __webpack_require__(33);
+var toPrimitive = __webpack_require__(35);
 var dP = Object.defineProperty;
 
 exports.f = __webpack_require__(4) ? Object.defineProperty : function defineProperty(O, P, Attributes) {
@@ -646,7 +659,7 @@ exports.f = __webpack_require__(4) ? Object.defineProperty : function defineProp
 
 
 /***/ }),
-/* 31 */
+/* 32 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(3);
@@ -657,16 +670,16 @@ module.exports = function (it) {
 
 
 /***/ }),
-/* 32 */
+/* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = !__webpack_require__(4) && !__webpack_require__(1)(function () {
-  return Object.defineProperty(__webpack_require__(33)('div'), 'a', { get: function () { return 7; } }).a != 7;
+  return Object.defineProperty(__webpack_require__(34)('div'), 'a', { get: function () { return 7; } }).a != 7;
 });
 
 
 /***/ }),
-/* 33 */
+/* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(3);
@@ -679,7 +692,7 @@ module.exports = function (it) {
 
 
 /***/ }),
-/* 34 */
+/* 35 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.1.1 ToPrimitive(input [, PreferredType])
@@ -697,7 +710,7 @@ module.exports = function (it, S) {
 
 
 /***/ }),
-/* 35 */
+/* 36 */
 /***/ (function(module, exports) {
 
 module.exports = function (bitmap, value) {
@@ -711,7 +724,7 @@ module.exports = function (bitmap, value) {
 
 
 /***/ }),
-/* 36 */
+/* 37 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -719,7 +732,7 @@ module.exports = function (bitmap, value) {
 
 exports.__esModule = true;
 
-var _assign = __webpack_require__(37);
+var _assign = __webpack_require__(38);
 
 var _assign2 = _interopRequireDefault(_assign);
 
@@ -740,39 +753,39 @@ exports.default = _assign2.default || function (target) {
 };
 
 /***/ }),
-/* 37 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = { "default": __webpack_require__(38), __esModule: true };
-
-/***/ }),
 /* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(39);
-module.exports = __webpack_require__(0).Object.assign;
-
+module.exports = { "default": __webpack_require__(39), __esModule: true };
 
 /***/ }),
 /* 39 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 19.1.3.1 Object.assign(target, source)
-var $export = __webpack_require__(12);
-
-$export($export.S + $export.F, 'Object', { assign: __webpack_require__(40) });
+__webpack_require__(40);
+module.exports = __webpack_require__(0).Object.assign;
 
 
 /***/ }),
 /* 40 */
 /***/ (function(module, exports, __webpack_require__) {
 
+// 19.1.3.1 Object.assign(target, source)
+var $export = __webpack_require__(12);
+
+$export($export.S + $export.F, 'Object', { assign: __webpack_require__(41) });
+
+
+/***/ }),
+/* 41 */
+/***/ (function(module, exports, __webpack_require__) {
+
 "use strict";
 
 // 19.1.2.1 Object.assign(target, source, ...)
 var getKeys = __webpack_require__(7);
-var gOPS = __webpack_require__(41);
-var pIE = __webpack_require__(42);
+var gOPS = __webpack_require__(42);
+var pIE = __webpack_require__(43);
 var toObject = __webpack_require__(5);
 var IObject = __webpack_require__(10);
 var $assign = Object.assign;
@@ -805,27 +818,27 @@ module.exports = !$assign || __webpack_require__(1)(function () {
 
 
 /***/ }),
-/* 41 */
+/* 42 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 
 /***/ }),
-/* 42 */
+/* 43 */
 /***/ (function(module, exports) {
 
 exports.f = {}.propertyIsEnumerable;
 
 
 /***/ }),
-/* 43 */
+/* 44 */
 /***/ (function(module, exports) {
 
 // removed by extract-text-webpack-plugin
 
 /***/ }),
-/* 44 */
+/* 45 */
 /***/ (function(module, exports) {
 
 // removed by extract-text-webpack-plugin

--- a/code-syntax.js
+++ b/code-syntax.js
@@ -3,7 +3,7 @@
  * A gutenberg block that allows inserting code with syntax highlighting.
  */
 
- /**
+/**
  * WordPress dependencies
  */
 const { __ } = wp.i18n;
@@ -18,23 +18,23 @@ import './editor.scss';
 import './style.scss';
 
 const langs = {
-	bash:       __( 'Bash (shell)', 'code-syntax-block' ),
-	clike:      __( 'C-like', 'code-syntax-block' ),
-	css:        __( 'CSS', 'code-syntax-block' ),
-	git:        __( 'Git', 'code-syntax-block' ),
-	go:         __( 'Go (golang)', 'code-syntax-block' ),
-	markup:     __( 'HTML/Markup', 'code-syntax-block' ),
+	bash: __( 'Bash (shell)', 'code-syntax-block' ),
+	clike: __( 'C-like', 'code-syntax-block' ),
+	css: __( 'CSS', 'code-syntax-block' ),
+	git: __( 'Git', 'code-syntax-block' ),
+	go: __( 'Go (golang)', 'code-syntax-block' ),
+	markup: __( 'HTML/Markup', 'code-syntax-block' ),
 	javascript: __( 'JavaScript', 'code-syntax-block' ),
-	json:       __( 'JSON', 'code-syntax-block' ),
-	markdown:   __( 'Markdown', 'code-syntax-block' ),
-	php:        __( 'PHP', 'code-syntax-block' ),
-	python:     __( 'Python', 'code-syntax-block' ),
-	jsx:        __( 'React JSX', 'code-syntax-block' ),
-	sql:        __( 'SQL', 'code-syntax-block' ),
+	json: __( 'JSON', 'code-syntax-block' ),
+	markdown: __( 'Markdown', 'code-syntax-block' ),
+	php: __( 'PHP', 'code-syntax-block' ),
+	python: __( 'Python', 'code-syntax-block' ),
+	jsx: __( 'React JSX', 'code-syntax-block' ),
+	sql: __( 'SQL', 'code-syntax-block' )
 };
 
 const addSyntaxToCodeBlock = settings => {
-	if ( settings.name !== "core/code" ) {
+	if ( 'core/code' !== settings.name ) {
 		return settings;
 	}
 
@@ -48,13 +48,13 @@ const addSyntaxToCodeBlock = settings => {
 				selector: 'code',
 				source: 'attribute',
 				attribute: 'lang'
-			},
+			}
 		},
 
-		edit( { attributes, setAttributes, isSelected, className } ) {
+		edit({ attributes, setAttributes, isSelected, className }) {
 
 			const updateLanguage = language => {
-				setAttributes( { language } );
+				setAttributes({ language });
 			};
 
 			return [
@@ -74,7 +74,7 @@ const addSyntaxToCodeBlock = settings => {
 				<div key="editor-wrapper" className={ className }>
 					<PlainText
 						value={ attributes.content }
-						onChange={ ( content ) => setAttributes( { content } ) }
+						onChange={ ( content ) => setAttributes({ content }) }
 						placeholder={ __( 'Write code…', 'code-syntax-block' ) }
 						aria-label={ __( 'Code', 'code-syntax-block' ) }
 					/>
@@ -83,10 +83,10 @@ const addSyntaxToCodeBlock = settings => {
 			];
 		},
 
-		save( { attributes } ) {
-			const cls = ( attributes.language ) ? "language-" + attributes.language : "";
+		save({ attributes }) {
+			const cls = ( attributes.language ) ? 'language-' + attributes.language : '';
 			return <pre><code lang={ attributes.language } className={ cls }>{ attributes.content }</code></pre>;
-		},
+		}
 	};
 
 	return newCodeBlockSettings;
@@ -94,7 +94,7 @@ const addSyntaxToCodeBlock = settings => {
 
 // Register Filter
 addFilter(
-	"blocks.registerBlockType",
-	"mkaz/code-syntax-block",
+	'blocks.registerBlockType',
+	'mkaz/code-syntax-block',
 	addSyntaxToCodeBlock
-)
+);

--- a/code-syntax.js
+++ b/code-syntax.js
@@ -34,7 +34,7 @@ const langs = {
 };
 
 const addSyntaxToCodeBlock = settings => {
-	if ( 'core/code' !== settings.name ) {
+	if ( settings.name !== 'core/code' ) {
 		return settings;
 	}
 

--- a/code-syntax.js
+++ b/code-syntax.js
@@ -18,19 +18,19 @@ import './editor.scss';
 import './style.scss';
 
 const langs = {
-	bash:       'Bash (shell)',
-	clike:      'C-like',
-	css:        'CSS',
-	git:        'Git',
-	go:         'Go (golang)',
-	markup:     'HTML/Markup',
-	javascript: 'JavaScript',
-	json:       'JSON',
-	markdown:   'Markdown',
-	php:        'PHP',
-	python:     'Python',
-	jsx:        'React JSX',
-	sql:        'SQL',
+	bash:       __( 'Bash (shell)', 'code-syntax-block' ),
+	clike:      __( 'C-like', 'code-syntax-block' ),
+	css:        __( 'CSS', 'code-syntax-block' ),
+	git:        __( 'Git', 'code-syntax-block' ),
+	go:         __( 'Go (golang)', 'code-syntax-block' ),
+	markup:     __( 'HTML/Markup', 'code-syntax-block' ),
+	javascript: __( 'JavaScript', 'code-syntax-block' ),
+	json:       __( 'JSON', 'code-syntax-block' ),
+	markdown:   __( 'Markdown', 'code-syntax-block' ),
+	php:        __( 'PHP', 'code-syntax-block' ),
+	python:     __( 'Python', 'code-syntax-block' ),
+	jsx:        __( 'React JSX', 'code-syntax-block' ),
+	sql:        __( 'SQL', 'code-syntax-block' ),
 };
 
 const addSyntaxToCodeBlock = settings => {
@@ -63,7 +63,7 @@ const addSyntaxToCodeBlock = settings => {
 						label="Language"
 						value={ attributes.language }
 						options={
-							[ { label: __( 'Select code language' ), value: '' } ].concat (
+							[ { label: __( 'Select code language', 'code-syntax-block' ), value: '' } ].concat (
 							Object.keys( langs ).map( ( lang ) => (
 								{ label: langs[lang], value: lang }
 							) ) )
@@ -75,8 +75,8 @@ const addSyntaxToCodeBlock = settings => {
 					<PlainText
 						value={ attributes.content }
 						onChange={ ( content ) => setAttributes( { content } ) }
-						placeholder={ __( 'Write code…' ) }
-						aria-label={ __( 'Code' ) }
+						placeholder={ __( 'Write code…', 'code-syntax-block' ) }
+						aria-label={ __( 'Code', 'code-syntax-block' ) }
 					/>
 					<div className="language-selected">{ langs[ attributes.language ] }</div>
 				</div>

--- a/code-syntax.js
+++ b/code-syntax.js
@@ -58,7 +58,7 @@ const addSyntaxToCodeBlock = settings => {
 			};
 
 			return [
-				<InspectorControls>
+				<InspectorControls key="controls">
 					<SelectControl
 						label="Language"
 						value={ attributes.language }
@@ -71,7 +71,7 @@ const addSyntaxToCodeBlock = settings => {
 						onChange={ updateLanguage }
 					/>
 				</InspectorControls>,
-				<div className={ className }>
+				<div key="editor-wrapper" className={ className }>
 					<PlainText
 						value={ attributes.content }
 						onChange={ ( content ) => setAttributes( { content } ) }

--- a/index.php
+++ b/index.php
@@ -8,9 +8,18 @@
  * Author URI:   https://mkaz.blog/
  * License:      GPL2
  * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:  code-syntax-block
  *
  * @package Code_Syntax_Block
  */
+
+/**
+ * Load text domain.
+ */
+function mkaz_load_plugin_textdomain() {
+	load_plugin_textdomain( 'code-syntax-block', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'mkaz_load_plugin_textdomain' );
 
 /**
  * Enqueue assets for editor portion of Gutenberg
@@ -24,7 +33,7 @@ function mkaz_code_syntax_editor_assets() {
 	wp_enqueue_script(
 		'mkaz-code-syntax',
 		plugins_url( $block_path, __FILE__ ),
-		array( 'wp-blocks', 'wp-element' ),
+		array( 'wp-blocks', 'wp-element', 'wp-i18n' ),
 		filemtime( plugin_dir_path( __FILE__ ) . $block_path )
 	);
 
@@ -34,6 +43,13 @@ function mkaz_code_syntax_editor_assets() {
 		plugins_url( $editor_style_path, __FILE__ ),
 		array( 'wp-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . $editor_style_path )
+	);
+
+	// Prepare Jed locale data.
+	$locale_data = gutenberg_get_jed_locale_data( 'code-syntax-block' );
+	wp_add_inline_script(
+		'wp-i18n',
+		sprintf( 'wp.i18n.setLocaleData( %s, "code-syntax-block" );', wp_json_encode( $locale_data ) )
 	);
 
 }

--- a/index.php
+++ b/index.php
@@ -1,38 +1,39 @@
 <?php
-/*
-Plugin Name:  Code Syntax Block
-Plugin URI:   https://github.com/mkaz/code-syntax-block
-Description:  A plugin to extend Gutenberg code block with syntax highlighting
-Version:      0.4.0
-Author:       Marcus Kazmierczak
-Author URI:   https://mkaz.blog/
-License:      GPL2
-License URI:  https://www.gnu.org/licenses/gpl-2.0.html
-*/
-
+/**
+ * Plugin Name:  Code Syntax Block
+ * Plugin URI:   https://github.com/mkaz/code-syntax-block
+ * Description:  A plugin to extend Gutenberg code block with syntax highlighting
+ * Version:      0.4.0
+ * Author:       Marcus Kazmierczak
+ * Author URI:   https://mkaz.blog/
+ * License:      GPL2
+ * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package Code_Syntax_Block
+ */
 
 /**
  * Enqueue assets for editor portion of Gutenberg
  */
 function mkaz_code_syntax_editor_assets() {
-	// files
-	$blockPath = 'build/block.built.js';
-	$editorStylePath = 'assets/blocks.editor.css';
+	// Files.
+	$block_path        = 'build/block.built.js';
+	$editor_style_path = 'assets/blocks.editor.css';
 
-	// block
+	// Block.
 	wp_enqueue_script(
 		'mkaz-code-syntax',
-		plugins_url( $blockPath, __FILE__ ),
-		[ 'wp-blocks', 'wp-element' ],
-		filemtime( plugin_dir_path(__FILE__) . $blockPath )
+		plugins_url( $block_path, __FILE__ ),
+		array( 'wp-blocks', 'wp-element' ),
+		filemtime( plugin_dir_path( __FILE__ ) . $block_path )
 	);
 
-	// enqueue editor style
+	// Enqueue editor style.
 	wp_enqueue_style(
 		'mkaz-code-syntax-editor-css',
-		plugins_url( $editorStylePath, __FILE__),
-		[ 'wp-blocks' ],
-		filemtime( plugin_dir_path( __FILE__ ) . $editorStylePath )
+		plugins_url( $editor_style_path, __FILE__ ),
+		array( 'wp-blocks' ),
+		filemtime( plugin_dir_path( __FILE__ ) . $editor_style_path )
 	);
 
 }
@@ -42,34 +43,34 @@ add_action( 'enqueue_block_editor_assets', 'mkaz_code_syntax_editor_assets' );
  * Enqueue assets for viewing posts
  */
 function mkaz_code_syntax_view_assets() {
-	// files
-	$viewStylePath = 'assets/blocks.style.css';
-	$prismJsPath = 'assets/prism.js';
-	$prismCssPath = 'assets/prism.css';
+	// Files.
+	$view_style_path = 'assets/blocks.style.css';
+	$prism_js_path   = 'assets/prism.js';
+	$prism_css_path  = 'assets/prism.css';
 
-	// enqueue view style
+	// Enqueue view style.
 	wp_enqueue_style(
 		'mkaz-code-syntax-css',
-		plugins_url( $viewStylePath, __FILE__ ),
-		[],
-		filemtime( plugin_dir_path(__FILE__) . $viewStylePath )
+		plugins_url( $view_style_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $view_style_path )
 	);
 
-	// enqueue prism style
+	// Enqueue prism style.
 	wp_enqueue_style(
 		'mkaz-code-syntax-prism-css',
-		plugins_url( $prismCssPath, __FILE__ ),
-		[],
-		filemtime( plugin_dir_path(__FILE__) . $prismCssPath )
+		plugins_url( $prism_css_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $prism_css_path )
 	);
 
-	// enqueue prism script
+	// Enqueue prism script.
 	wp_enqueue_script(
 		'mkaz-code-syntax-prism-css',
-		plugins_url( $prismJsPath, __FILE__ ),
-		[], // no dependencies
-		filemtime( plugin_dir_path(__FILE__) . $prismJsPath ),
-		true // in footer
+		plugins_url( $prism_js_path, __FILE__ ),
+		array(), // No dependencies.
+		filemtime( plugin_dir_path( __FILE__ ) . $prism_js_path ),
+		true // In footer.
 	);
 }
-add_action('wp_enqueue_scripts', 'mkaz_code_syntax_view_assets');
+add_action( 'wp_enqueue_scripts', 'mkaz_code_syntax_view_assets' );

--- a/languages/code-syntax-block.pot
+++ b/languages/code-syntax-block.pot
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2018-08-11T22:51:33+00:00\n"
-"PO-Revision-Date: 2018-08-11T22:51:33+00:00\n"
-"X-Generator: WP-CLI 2.0.0\n"
+"POT-Creation-Date: 2018-10-19T21:59:40+00:00\n"
+"PO-Revision-Date: 2018-10-19T21:59:40+00:00\n"
+"X-Generator: WP-CLI 2.0.1\n"
 "X-Domain: code-syntax-block\n"
 
 #. Plugin Name of the plugin

--- a/languages/code-syntax-block.pot
+++ b/languages/code-syntax-block.pot
@@ -1,0 +1,99 @@
+# Copyright (C) 2018 Marcus Kazmierczak
+# This file is distributed under the same license as the Code Syntax Block plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Code Syntax Block 0.4.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/code-syntax-block\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-08-11T22:51:33+00:00\n"
+"PO-Revision-Date: 2018-08-11T22:51:33+00:00\n"
+"X-Generator: WP-CLI 2.0.0\n"
+"X-Domain: code-syntax-block\n"
+
+#. Plugin Name of the plugin
+msgid "Code Syntax Block"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://github.com/mkaz/code-syntax-block"
+msgstr ""
+
+#. Description of the plugin
+msgid "A plugin to extend Gutenberg code block with syntax highlighting"
+msgstr ""
+
+#. Author of the plugin
+msgid "Marcus Kazmierczak"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://mkaz.blog/"
+msgstr ""
+
+#: code-syntax.js:21
+msgid "Bash (shell)"
+msgstr ""
+
+#: code-syntax.js:22
+msgid "C-like"
+msgstr ""
+
+#: code-syntax.js:23
+msgid "CSS"
+msgstr ""
+
+#: code-syntax.js:24
+msgid "Git"
+msgstr ""
+
+#: code-syntax.js:25
+msgid "Go (golang)"
+msgstr ""
+
+#: code-syntax.js:26
+msgid "HTML/Markup"
+msgstr ""
+
+#: code-syntax.js:27
+msgid "JavaScript"
+msgstr ""
+
+#: code-syntax.js:28
+msgid "JSON"
+msgstr ""
+
+#: code-syntax.js:29
+msgid "Markdown"
+msgstr ""
+
+#: code-syntax.js:30
+msgid "PHP"
+msgstr ""
+
+#: code-syntax.js:31
+msgid "Python"
+msgstr ""
+
+#: code-syntax.js:32
+msgid "React JSX"
+msgstr ""
+
+#: code-syntax.js:33
+msgid "SQL"
+msgstr ""
+
+#: code-syntax.js:66
+msgid "Select code language"
+msgstr ""
+
+#: code-syntax.js:78
+msgid "Write code…"
+msgstr ""
+
+#: code-syntax.js:79
+msgid "Code"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
 		"babel-preset-env": "^1.6.0",
 		"cross-env": "^5.1.4",
 		"css-loader": "^0.28.11",
+		"eslint": "^5.3.0",
+		"eslint-config-wordpress": "^2.0.0",
 		"extract-text-webpack-plugin": "^3.0.2",
 		"node-sass": "^4.8.3",
 		"postcss-loader": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
 		"webpack": "^3.1.0"
 	},
 	"scripts": {
-		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
+		"make-pot": "wp i18n make-pot . languages/code-syntax-block.pot --include=code-syntax.js",
+		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack; npm run make-pot",
 		"dev": "cross-env BABEL_ENV=default webpack --watch",
-		"zip": "zip -r code-syntax-block.zip index.php readme.md assets build"
+		"zip": "zip -r code-syntax-block.zip index.php readme.md assets build languages"
 	}
 }


### PR DESCRIPTION
* Fix warning regarding lack of "key" prop in React.
* Allow code language names to be translated.
* Add text domain to translation function calls.
* Generate POT file and load.
* Add ESLint configuration and apply fixes.
* Fix PHPCS issues for WordPress Coding Standards.