### PR TITLE
Try to use core js translation functionality, fall back to Gutenberg

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,12 +45,16 @@ function mkaz_code_syntax_editor_assets() {
 		filemtime( plugin_dir_path( __FILE__ ) . $block_path )
 	);
 
-	// Prepare Jed locale data.
-	$locale_data = gutenberg_get_jed_locale_data( 'code-syntax-block' );
-	wp_add_inline_script(
-		'wp-i18n',
-		sprintf( 'wp.i18n.setLocaleData( %s, "code-syntax-block" );', wp_json_encode( $locale_data ) )
-	);
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( 'mkaz-code-syntax', 'code-syntax-block', plugin_dir_path( __FILE__ ) . 'languages' );
+	} else {
+		// Prepare Jed locale data.
+		$locale_data = gutenberg_get_jed_locale_data( 'code-syntax-block' );
+		wp_add_inline_script(
+			'wp-i18n',
+			sprintf( 'wp.i18n.setLocaleData( %s, "code-syntax-block" );', wp_json_encode( $locale_data ) )
+		);
+	}
 
 }
 add_action( 'enqueue_block_editor_assets', 'mkaz_code_syntax_editor_assets' );


### PR DESCRIPTION
In WP 5.0, we can use `wp_set_script_translations()` to easily enqueue the correct JS translations for `wp-i18n`.

Here it checks for that function first and uses it, then falls back to older the Gutenberg function if it's not available (i.e. WordPress 4.9.8). 

Fixes #25 