### PR TITLE
Remove reduced margin for Gutenberg block

### DIFF
--- a/assets/prism/prism.css
+++ b/assets/prism/prism.css
@@ -38,7 +38,6 @@
  /* Code blocks */
  pre[class*="language-"] {
 	 padding: 1em;
-	 margin: .5em 0;
 	 overflow: auto;
 	 border: 1px solid #dddddd;
 	 background-color: white;


### PR DESCRIPTION
The additional margin property reduces the margin between the code block and the subsequent block. removing this property maintains the original margin set by the Gutenberg.