### PR TITLE
Add filter to force loading assets

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Code Syntax Block
  * Plugin URI:   https://github.com/mkaz/code-syntax-block
  * Description:  A plugin to extend Gutenberg code block with syntax highlighting
- * Version:      1.2.3
+ * Version:      1.2.4
  * Author:       Marcus Kazmierczak
  * Author URI:   https://mkaz.blog/
  * License:      GPL2
@@ -14,7 +14,7 @@
  */
 
 // version added, used in URL
-define( 'MKAZ_CODE_SYNTAX_BLOCK_VERSION', '1.2.2' );
+define( 'MKAZ_CODE_SYNTAX_BLOCK_VERSION', '1.2.4' );
 require dirname( __FILE__ ) . '/prism-languages.php';
 
 /**
@@ -67,10 +67,24 @@ add_action( 'enqueue_block_editor_assets', function() {
 add_action( 'wp_enqueue_scripts', function() {
 	global $posts;
 
-	$found_block = array_reduce( $posts, function($found, $post) {
-		return $found || has_block( 'code', $post );
-	}, false );
-	if ( ! $found_block ) { return; }
+	/**
+	 * Filter forces loading assets event if no block detected
+	 *
+	 * @since 1.2.4
+	 *
+	 */
+	$force_load = apply_filters( 'mkaz_code_syntax_force_loading', false );
+	// if not forcing the loading of assets check if the block
+	// is found and if no block skip loading assets
+	if ( ! $force_load ) {
+		$found_block = array_reduce( $posts, function($found, $post) {
+			return $found || has_block( 'code', $post );
+		}, false );
+
+		if ( ! $found_block ) {
+			return;
+		}
+	}
 
 	// Files.
 	$view_style_path = 'assets/blocks.style.css';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mkaz-code-syntax-block",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "GPL-2.0-or-later",
   "main": "src/index.js",
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -77,8 +77,17 @@ add_filter( 'mkaz_code_syntax_language_list', function() {
 You can also **set a default language** using the filter `mkaz_code_syntax_default_lang`, by default no default is set requiring you to select the language. By setting a default language when inserting a code block the language will already be set, you can still change if you wish to show code not using the default language.
 
 This example would set JavaScript as the default:
+
 ```php
 add_filter( 'mkaz_code_syntax_default_lang', function() { return 'javascript'; });
+```
+
+### Conditional Loading
+
+By default the plugin will check if the current loop `has_blocks` and will only load the assets if the blocks are detected. If you need to override this, and force loading of assets using the following filter in your theme:
+
+```php
+add_filter( 'mkaz_code_syntax_force_loading', '__return_true' );
 ```
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: code, code syntax, syntax highlight, code highlighting
 Requires at least: 5.0
 Tested up to: 5.3.2
 Requires PHP: 5.2.4
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,14 @@ This example would set JavaScript as the default:
 
     add_filter( 'mkaz_code_syntax_default_lang', function() { return 'javascript'; });
 
+= Can I override the conditional loading, so assets always load? =
+
+Yes, use the filter `mkaz_code_syntax_force_loading` to force always loading assets, otherwise it users has_block to check.
+
+Example:
+
+	add_filter( 'mkaz_code_syntax_force_loading', '__return_true' );
+
 
 == Screenshots ==
 
@@ -100,6 +108,10 @@ This example would set JavaScript as the default:
 2. In Editor Example
 
 == Changelog ==
+
+= 1.24 =
+
+Add filter to force loading assets, regardless of has_block
 
 = 1.2.3 =
 


### PR DESCRIPTION
Fixes #61

Adds `mkaz_code_syntax_force_loading` filter to skip the conditional loading check and forces the assets to be loaded regardless of `has_blocks` checks.