### PR TITLE
Avoid a PHP Warning when no posts exist on the current page

### DIFF
--- a/index.php
+++ b/index.php
@@ -79,6 +79,10 @@ add_action( 'enqueue_block_assets', function() {
 		// if not forcing the loading of assets check if the block
 		// is found and if no block skip loading assets
 		if ( ! $force_load ) {
+			if ( empty( $posts ) ) {
+				return;
+			}
+
 			$found_block = array_reduce( $posts, function($found, $post) {
 				return $found || has_block( 'code', $post );
 			}, false );


### PR DESCRIPTION
Fixes warnings such as:
> PHP Warning:  array_reduce() expects parameter 1 to be array, null given in wp-content/plugins/code-syntax-block/index.php on line 84