### PR TITLE
Changed lang attribute to data-lang for AAA in screen readers

### DIFF
--- a/index.php
+++ b/index.php
@@ -193,10 +193,10 @@ function mkaz_prism_theme_css_ver() {
 add_filter( 'wp_kses_allowed_html', function( $tags ) {
 
 	if ( is_array( $tags['code'] ) ) {
-		$tags['code']['lang'] = array();
+		$tags['code']['data-lang'] = array();
 	} else {
 		$tags['code'] = array(
-			'lang' => array(),
+			'data-lang' => array(),
 		);
 	}
     return $tags;

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const addSyntaxToCodeBlock = ( settings ) => {
 				type: 'string',
 				selector: 'code',
 				source: 'attribute',
-				attribute: 'lang',
+				attribute: 'data-lang',
 			},
 			lineNumbers: {
 				type: 'boolean',

--- a/src/save.js
+++ b/src/save.js
@@ -5,7 +5,7 @@ const save = ( { attributes } ) => {
 	cls = ( attributes.lineNumbers ) ? cls + ' line-numbers' : cls;
 	return (
 		<pre title={ attributes.title }>
-			<code lang={ attributes.language } className={ cls }>
+			<code data-lang={ attributes.language } className={ cls }>
 				{ attributes.content }
 			</code>
 		</pre>


### PR DESCRIPTION
Please check that all is ok (I made the edits in Github).

Finally, my other Slack comment about AAA spec contrast:

* I changed `prism.css` to https://github.com/PrismJS/prism-themes/blob/master/themes/prism-a11y-dark.css (and changed `line-height` to `1.2`) because these styles are fully a11y compatible (https://www.a11yproject.com/) if you maintain actual `prism.css` file, maybe would be an excellent option to mentions this CSS in the readme file (light version also available https://raw.githubusercontent.com/ericwbailey/a11y-syntax-highlighting/master/dist/prism/a11y-light.css)

Thanks a lot.