### PR TITLE
Add support for GB 9.2 / WP 5.6 with useBlockProps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .vscode/
 dist/
+build/
 svn/
 node_modules
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@wordpress/eslint-plugin": "^7.3.0",
     "@wordpress/prettier-config": "^0.4.0",
     "@wordpress/scripts": "^12.3.0",
+    "eslint": "^4.19.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "mkaz-code-syntax-block",
   "version": "1.3.5",
   "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mkaz/code-syntax-block.git"
+  },
   "main": "src/index.js",
   "devDependencies": {
-    "@wordpress/eslint-plugin": "^3.1.0",
-    "@wordpress/prettier-config": "^0.3.0",
-    "@wordpress/scripts": "^5.1.0",
-    "eslint-plugin-eslint-comments": "^3.1.2",
-    "eslint-plugin-import": "^2.18.2"
+    "@wordpress/eslint-plugin": "^7.3.0",
+    "@wordpress/prettier-config": "^0.4.0",
+    "@wordpress/scripts": "^12.3.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.22.1"
   },
   "prettier": "@wordpress/prettier-config",
   "scripts": {

--- a/src/edit.js
+++ b/src/edit.js
@@ -53,6 +53,13 @@ const edit = ( { attributes, className, setAttributes } ) => {
 		false
 	);
 
+	const plainTextProps = {
+		value: attributes.content,
+		onChange: ( content ) => setAttributes( { content } ),
+		placeholder: __( 'Write code…' ),
+		'aria-label': __( 'Code' ),
+	};
+
 	const OldLightBlock = () =>
 		useLightBlockWrapper ? (
 			<Block.pre>
@@ -65,13 +72,6 @@ const edit = ( { attributes, className, setAttributes } ) => {
 		) : (
 			<PlainText { ...plainTextProps } />
 		);
-
-	const plainTextProps = {
-		value: attributes.content,
-		onChange: ( content ) => setAttributes( { content } ),
-		placeholder: __( 'Write code…' ),
-		'aria-label': __( 'Code' ),
-	};
 
 	return (
 		<>

--- a/src/save.js
+++ b/src/save.js
@@ -1,14 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
 
 const save = ( { attributes } ) => {
 	let cls = '';
-	cls = ( attributes.language ) ? 'language-' + attributes.language : '';
-	cls = ( attributes.lineNumbers ) ? cls + ' line-numbers' : cls;
+	cls = attributes.language ? 'language-' + attributes.language : '';
+	cls = attributes.lineNumbers ? cls + ' line-numbers' : cls;
+
+	const blockProps = useBlockProps?.save( { title: attributes.title } );
 	return (
-		<pre title={ attributes.title }>
-			<code lang={ attributes.language } className={ cls }>
-				{ attributes.content }
-			</code>
-		</pre>
+		<>
+			{ blockProps ? (
+				<pre { ...blockProps }>
+					<code lang={ attributes.language } className={ cls }>
+						{ attributes.content }
+					</code>
+				</pre>
+			) : (
+				<pre className="wp-block-code" title={ attributes.title }>
+					<code lang={ attributes.language } className={ cls }>
+						{ attributes.content }
+					</code>
+				</pre>
+			) }
+		</>
 	);
 };
 

--- a/src/save.js
+++ b/src/save.js
@@ -1,30 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 const save = ( { attributes } ) => {
 	let cls = '';
 	cls = attributes.language ? 'language-' + attributes.language : '';
 	cls = attributes.lineNumbers ? cls + ' line-numbers' : cls;
 
-	const blockProps = useBlockProps?.save( { title: attributes.title } );
-	return (
-		<>
-			{ blockProps ? (
+	// WP 5.6 / GB 9.2
+	if ( useBlockProps ) {
+		const blockProps = useBlockProps.save( { title: attributes.title } );
+		return (
+			<>
 				<pre { ...blockProps }>
-					<code lang={ attributes.language } className={ cls }>
-						{ attributes.content }
-					</code>
+					<RichText.Content
+						tagName="code"
+						value={ attributes.content }
+						lang={ attributes.language }
+						className={ cls }
+					/>
 				</pre>
-			) : (
-				<pre className="wp-block-code" title={ attributes.title }>
-					<code lang={ attributes.language } className={ cls }>
-						{ attributes.content }
-					</code>
-				</pre>
-			) }
-		</>
+			</>
+		);
+	}
+
+	// Backward compatibility < WP 5.6
+	return (
+		<pre className="wp-block-code" title={ attributes.title }>
+			<code lang={ attributes.language } className={ cls }>
+				{ attributes.content }
+			</code>
+		</pre>
 	);
 };
 


### PR DESCRIPTION

The previous useLightWrapper is being switched out for useBlockProps in GB 9.2, that will also be in WP 5.6.

This PR adds an additional check for support and uses the latest version of wrapping the component to support the upcoming version, current WP 5.5, and previous versions.
