### PR TITLE
Add default color for wp-block-code code

### DIFF
--- a/assets/prism-a11y-dark.css
+++ b/assets/prism-a11y-dark.css
@@ -4,161 +4,165 @@
  * @author ericwbailey
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-	 color: #f8f8f2;
-	 background: none;
-	 font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	 text-align: left;
-	 white-space: pre;
-	 word-spacing: normal;
-	 word-break: normal;
-	 word-wrap: normal;
-	 line-height: 1.5;
+pre.wp-block-code code {
+	color: #f8f8f2;
+}
 
-	 -moz-tab-size: 4;
-	 -o-tab-size: 4;
-	 tab-size: 4;
+code[class*="language-"],
+pre[class*="language-"] {
+    color: #f8f8f2;
+    background: none;
+    font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
 
-	 -webkit-hyphens: none;
-	 -moz-hyphens: none;
-	 -ms-hyphens: none;
-	 hyphens: none;
- }
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
 
- /* Code blocks */
- pre[class*="language-"] {
-	 padding: 1em;
-	 margin: 0.5em auto;
-	 overflow: auto;
-	 border-radius: 0.3em;
- }
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+}
 
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-	 background: #2b2b2b;
- }
+/* Code blocks */
+pre[class*="language-"] {
+    padding: 1em;
+    margin: 0.5em auto;
+    overflow: auto;
+    border-radius: 0.3em;
+}
 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-	 padding: 0.1em;
-	 border-radius: 0.3em;
-	 white-space: normal;
- }
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+    background: #2b2b2b;
+}
 
- .token.comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-	 color: #d4d0ab;
- }
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+    padding: 0.1em;
+    border-radius: 0.3em;
+    white-space: normal;
+}
 
- .token.punctuation {
-	 color: #fefefe;
- }
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #d4d0ab;
+}
 
- .token.property,
- .token.tag,
- .token.constant,
- .token.symbol,
- .token.deleted {
-	 color: #ffa07a;
- }
+.token.punctuation {
+    color: #fefefe;
+}
 
- .token.boolean,
- .token.number {
-	 color: #00e0e0;
- }
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #ffa07a;
+}
 
- .token.selector,
- .token.attr-name,
- .token.string,
- .token.char,
- .token.builtin,
- .token.inserted {
-	 color: #abe338;
- }
+.token.boolean,
+.token.number {
+    color: #00e0e0;
+}
 
- .token.operator,
- .token.entity,
- .token.url,
- .language-css .token.string,
- .style .token.string,
- .token.variable {
-	 color: #00e0e0;
- }
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #abe338;
+}
 
- .token.atrule,
- .token.attr-value,
- .token.function {
-	 color: #ffd700;
- }
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+    color: #00e0e0;
+}
 
- .token.keyword {
-	 color: #00e0e0;
- }
+.token.atrule,
+.token.attr-value,
+.token.function {
+    color: #ffd700;
+}
 
- .token.regex,
- .token.important {
-	 color: #ffd700;
- }
+.token.keyword {
+    color: #00e0e0;
+}
 
- .token.important,
- .token.bold {
-	 font-weight: bold;
- }
+.token.regex,
+.token.important {
+    color: #ffd700;
+}
 
- .token.italic {
-	 font-style: italic;
- }
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
 
- .token.entity {
-	 cursor: help;
- }
+.token.italic {
+    font-style: italic;
+}
 
- @media screen and (-ms-high-contrast: active) {
-	 code[class*="language-"],
-	 pre[class*="language-"] {
-		 color: windowText;
-		 background: window;
-	 }
+.token.entity {
+    cursor: help;
+}
 
-	 :not(pre) > code[class*="language-"],
-	 pre[class*="language-"] {
-		 background: window;
-	 }
+@media screen and (-ms-high-contrast: active) {
+    code[class*="language-"],
+    pre[class*="language-"] {
+   	 color: windowText;
+   	 background: window;
+    }
 
-	 .token.important {
-		 background: highlight;
-		 color: window;
-		 font-weight: normal;
-	 }
+    :not(pre) > code[class*="language-"],
+    pre[class*="language-"] {
+   	 background: window;
+    }
 
-	 .token.atrule,
-	 .token.attr-value,
-	 .token.function,
-	 .token.keyword,
-	 .token.operator,
-	 .token.selector {
-		 font-weight: bold;
-	 }
+    .token.important {
+   	 background: highlight;
+   	 color: window;
+   	 font-weight: normal;
+    }
 
-	 .token.attr-value,
-	 .token.comment,
-	 .token.doctype,
-	 .token.function,
-	 .token.keyword,
-	 .token.operator,
-	 .token.property,
-	 .token.string {
-		 color: highlight;
-	 }
+    .token.atrule,
+    .token.attr-value,
+    .token.function,
+    .token.keyword,
+    .token.operator,
+    .token.selector {
+   	 font-weight: bold;
+    }
 
-	 .token.attr-value,
-	 .token.url {
-		 font-weight: normal;
-	 }
- }
+    .token.attr-value,
+    .token.comment,
+    .token.doctype,
+    .token.function,
+    .token.keyword,
+    .token.operator,
+    .token.property,
+    .token.string {
+   	 color: highlight;
+    }
+
+    .token.attr-value,
+    .token.url {
+   	 font-weight: normal;
+    }
+}
 
 
 pre.line-numbers {

--- a/assets/prism-ghcolors.css
+++ b/assets/prism-ghcolors.css
@@ -3,118 +3,122 @@
  * Inspired by Github syntax coloring
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
+pre.wp-block-code code {
 	color: #393A34;
-	font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	direction: ltr;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	line-height: 1.2em;
+}
 
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
+code[class*="language-"],
+pre[class*="language-"] {
+   color: #393A34;
+   font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+   direction: ltr;
+   text-align: left;
+   white-space: pre;
+   word-spacing: normal;
+   word-break: normal;
+   line-height: 1.2em;
 
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
- }
+   -moz-tab-size: 4;
+   -o-tab-size: 4;
+   tab-size: 4;
 
- pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
- code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-	 background: #b3d4fc;
- }
+   -webkit-hyphens: none;
+   -moz-hyphens: none;
+   -ms-hyphens: none;
+   hyphens: none;
+}
 
- pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
- code[class*="language-"]::selection, code[class*="language-"] ::selection {
-	 background: #b3d4fc;
- }
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+    background: #b3d4fc;
+}
 
- /* Code blocks */
- pre[class*="language-"] {
-	 padding: 1em;
-	 margin: .5em auto;
-	 overflow: auto;
-	 border: 1px solid #dddddd;
-	 background-color: white;
- }
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+    background: #b3d4fc;
+}
 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-	 padding: .2em;
-	 padding-top: 1px;
-	 padding-bottom: 1px;
-	 background: #f8f8f8;
-	 border: 1px solid #dddddd;
- }
+/* Code blocks */
+pre[class*="language-"] {
+    padding: 1em;
+    margin: .5em auto;
+    overflow: auto;
+    border: 1px solid #dddddd;
+    background-color: white;
+}
 
- .token.comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-	 color: #999988;
-	 font-style: italic;
- }
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+    padding: .2em;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    background: #f8f8f8;
+    border: 1px solid #dddddd;
+}
 
- .token.namespace {
-	 opacity: .7;
- }
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #999988;
+    font-style: italic;
+}
 
- .token.string,
- .token.attr-value {
-	 color: #e3116c;
- }
+.token.namespace {
+    opacity: .7;
+}
 
- .token.punctuation,
- .token.operator {
-	 color: #393A34; /* no highlight */
- }
+.token.string,
+.token.attr-value {
+    color: #e3116c;
+}
 
- .token.entity,
- .token.url,
- .token.symbol,
- .token.number,
- .token.boolean,
- .token.variable,
- .token.constant,
- .token.property,
- .token.regex,
- .token.inserted {
-	 color: #36acaa;
- }
+.token.punctuation,
+.token.operator {
+    color: #393A34; /* no highlight */
+}
 
- .token.atrule,
- .token.keyword,
- .token.attr-name,
- .language-autohotkey .token.selector {
-	 color: #00a4db;
- }
+.token.entity,
+.token.url,
+.token.symbol,
+.token.number,
+.token.boolean,
+.token.variable,
+.token.constant,
+.token.property,
+.token.regex,
+.token.inserted {
+    color: #36acaa;
+}
 
- .token.function,
- .token.deleted,
- .language-autohotkey .token.tag {
-	 color: #9a050f;
- }
+.token.atrule,
+.token.keyword,
+.token.attr-name,
+.language-autohotkey .token.selector {
+    color: #00a4db;
+}
 
- .token.tag,
- .token.selector,
- .language-autohotkey .token.keyword {
-	 color: #00009f;
- }
+.token.function,
+.token.deleted,
+.language-autohotkey .token.tag {
+    color: #9a050f;
+}
 
- .token.important,
- .token.function,
- .token.bold {
-	 font-weight: bold;
- }
+.token.tag,
+.token.selector,
+.language-autohotkey .token.keyword {
+    color: #00009f;
+}
 
- .token.italic {
-	 font-style: italic;
- }
+.token.important,
+.token.function,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
+}
 
 
 pre.line-numbers {

--- a/assets/prism-nord.css
+++ b/assets/prism-nord.css
@@ -5,123 +5,127 @@
  * Ported for PrismJS by Zane Hitchcoxc (@zwhitchcox) and Gabriel Ramos (@gabrieluizramos)
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-	 color: #f8f8f2;
-	 background: none;
-	 font-family: Hack, "Fira Code", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	 text-align: left;
-	 white-space: pre;
-	 word-spacing: normal;
-	 word-break: normal;
-	 word-wrap: normal;
-	 line-height: 1.5;
-	 -moz-tab-size: 4;
-	 -o-tab-size: 4;
-	 tab-size: 4;
-	 -webkit-hyphens: none;
-	 -moz-hyphens: none;
-	 -ms-hyphens: none;
-	 hyphens: none;
- }
+pre.wp-block-code code {
+	color: #f8f8f2;
+}
 
- /* Code blocks */
- pre[class*="language-"] {
-	 padding: 1em;
-	 margin: .5em auto;
-	 overflow: auto;
-	 border-radius: 0.3em;
- }
+code[class*="language-"],
+pre[class*="language-"] {
+    color: #f8f8f2;
+    background: none;
+    font-family: Hack, "Fira Code", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+}
 
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-	 background: #2E3440;
- }
+/* Code blocks */
+pre[class*="language-"] {
+    padding: 1em;
+    margin: .5em auto;
+    overflow: auto;
+    border-radius: 0.3em;
+}
 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-	 padding: .1em;
-	 border-radius: .3em;
-	 white-space: normal;
- }
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+    background: #2E3440;
+}
 
- .token.comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-	 color: #636f88;
- }
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+    padding: .1em;
+    border-radius: .3em;
+    white-space: normal;
+}
 
- .token.punctuation {
-	 color: #81A1C1;
- }
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #636f88;
+}
 
- .namespace {
-	 opacity: .7;
- }
+.token.punctuation {
+    color: #81A1C1;
+}
 
- .token.property,
- .token.tag,
- .token.constant,
- .token.symbol,
- .token.deleted {
-	 color: #81A1C1;
- }
+.namespace {
+    opacity: .7;
+}
 
- .token.number {
-	 color: #B48EAD;
- }
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #81A1C1;
+}
 
- .token.boolean {
-	 color: #81A1C1;
- }
+.token.number {
+    color: #B48EAD;
+}
 
- .token.selector,
- .token.attr-name,
- .token.string,
- .token.char,
- .token.builtin,
- .token.inserted {
-	 color: #A3BE8C;
- }
+.token.boolean {
+    color: #81A1C1;
+}
 
- .token.operator,
- .token.entity,
- .token.url,
- .language-css .token.string,
- .style .token.string,
- .token.variable {
-	 color: #81A1C1;
- }
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #A3BE8C;
+}
 
- .token.atrule,
- .token.attr-value,
- .token.function,
- .token.class-name {
-	 color: #88C0D0;
- }
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+    color: #81A1C1;
+}
 
- .token.keyword {
-	 color: #81A1C1;
- }
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+    color: #88C0D0;
+}
 
- .token.regex,
- .token.important {
-	 color: #EBCB8B;
- }
+.token.keyword {
+    color: #81A1C1;
+}
 
- .token.important,
- .token.bold {
-	 font-weight: bold;
- }
+.token.regex,
+.token.important {
+    color: #EBCB8B;
+}
 
- .token.italic {
-	 font-style: italic;
- }
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
 
- .token.entity {
-	 cursor: help;
- }
+.token.italic {
+    font-style: italic;
+}
+
+.token.entity {
+    cursor: help;
+}
 
 
 pre.line-numbers {

--- a/assets/prism-onedark.css
+++ b/assets/prism-onedark.css
@@ -6,6 +6,11 @@
  * @author Lea Verou
  *
  */
+
+pre.wp-block-code code {
+  color: #ABB2BF;
+}
+
 code[class*="language-"],
 pre[class*="language-"] {
   color: #ABB2BF;

--- a/assets/prism.css
+++ b/assets/prism.css
@@ -4,6 +4,10 @@
  * @author ericwbailey
  */
 
+.wp-block-code code {
+	color: #f8f8f2;
+}
+
  code[class*="language-"],
  pre[class*="language-"] {
 	 color: #f8f8f2;


### PR DESCRIPTION
The TwentyTwentyOne theme specifies a color for code blocks, the [CSS specification is here](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-content/themes/twentytwentyone/style.css#L1925). For dark mode, the color is light, and when dark mode is enable but in a light mode, the color is dark.

This setting from the theme is overriding the color scheme for the syntax block, which is often opposite the page. For example, the default code block uses a black background, so if any text is entered that is not a keyword, string, etc.. it gets the default color from the theme.

This change adds a default color for `pre.wp-block-code code` to the color schemes shipped with this plugin.

Fixes #98