### PR TITLE
Support for BBcode

### DIFF
--- a/prism-languages.php
+++ b/prism-languages.php
@@ -10,6 +10,7 @@ function mkaz_code_syntax_block_get_supported_languages() {
 		"apacheconf" => "Apache Config",
 		"bash" => "Bash/Shell",
 		"basic" => "BASIC",
+		"bbcode" => "BBcode",
 		"c" => "C-like",
 		"csharp" => "C#",
 		"cpp" => "C++",


### PR DESCRIPTION
The array has been extended to support BBcode out of the box. This is especially useful for WordPress posts that want to present BBcode in examples (since WordPress shortcodes are basically BBcode).