### PR TITLE
Adds gml/GameMaker Language as a language selection.

### DIFF
--- a/prism-languages.php
+++ b/prism-languages.php
@@ -21,6 +21,7 @@ function mkaz_code_syntax_block_get_supported_languages() {
 		"fsharp" => "F#",
 		"graphql" => "GraphQL",
 		"go" => "Go",
+		"gml" => "GameMaker Language",
 		"haskell" => "Haskell",
 		"markup" => "HTML",
 		"java" => "Java",


### PR DESCRIPTION
I have a wordpress blog where I like to primarly provide GameMaker code. While I'm able to add this entry in every plugin update, it would really save me some time of micromanaging these if it was included off the bat.